### PR TITLE
Ignore animated block tiles

### DIFF
--- a/src/main/java/org/terasology/tintOverlay/TintOverlayBlockTileProducer.java
+++ b/src/main/java/org/terasology/tintOverlay/TintOverlayBlockTileProducer.java
@@ -39,8 +39,9 @@ public class TintOverlayBlockTileProducer extends BaseTintOverlayProducer implem
 
     @Override
     public Optional<TileData> getAssetData(ResourceUrn urn) throws IOException {
-        BufferedImage resultImage = createImage(urn);
-        if (resultImage != null) {
+        BufferedImage[] resultImage = new BufferedImage[1];
+        resultImage[0] = createImage(urn);
+        if (resultImage[0] != null) {
             return Optional.of(new TileData(resultImage, false));
         }
 
@@ -52,7 +53,7 @@ public class TintOverlayBlockTileProducer extends BaseTintOverlayProducer implem
         // attempt to get an existing block tile
         Optional<BlockTile> resourceBlockTile = Assets.get(resourceUri, BlockTile.class);
         if (resourceBlockTile.isPresent()) {
-            return resourceBlockTile.get().getImage();
+            return resourceBlockTile.get().getImage(0);
         }
 
         // try and get it as a normal texture


### PR DESCRIPTION
Make compatible with the engine's animated block tiles, but don't
actually apply animated textures to the items rendered by this
module.